### PR TITLE
Import from '../' instead of '..'

### DIFF
--- a/src/utils/__tests__/get-emoji-data-from-native.test.js
+++ b/src/utils/__tests__/get-emoji-data-from-native.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import {getEmojiDataFromNative} from '..'
+import {getEmojiDataFromNative} from '../'
 
 import data from '../../../data/apple'
 

--- a/src/utils/emoji-index/nimble-emoji-index.js
+++ b/src/utils/emoji-index/nimble-emoji-index.js
@@ -1,4 +1,4 @@
-import {getData, getSanitizedData, intersect} from '..'
+import {getData, getSanitizedData, intersect} from '../'
 import {uncompress} from '../data'
 import store from '../store'
 


### PR DESCRIPTION
For some poorly understood reason, the `'..'` import is causing an error in Metro/Expo. This shouldn't make a difference anywhere else.

Fixes #67 