### PR TITLE
fix(spriteSheetFn): the default spriteSheetFn prop is broken

### DIFF
--- a/src/utils/shared-default-props.js
+++ b/src/utils/shared-default-props.js
@@ -7,9 +7,9 @@ const EmojiDefaultProps = {
   native: false,
   forceSize: false,
   tooltip: false,
-  spriteSheetFn: (set, sheetSize) => {
+  spriteSheetFn: (set, sheetSize) => ({
     uri: `https://unpkg.com/emoji-datasource-${set}@${EMOJI_DATASOURCE_VERSION}/img/${set}/sheets-256/${sheetSize}.png`
-  },
+  }),
   emojiImageFn: (image) => image,
   onPress: () => {},
   onLongPress: () => {},

--- a/src/utils/shared-default-props.js
+++ b/src/utils/shared-default-props.js
@@ -8,7 +8,7 @@ const EmojiDefaultProps = {
   forceSize: false,
   tooltip: false,
   spriteSheetFn: (set, sheetSize) => ({
-    uri: `https://unpkg.com/emoji-datasource-${set}@${EMOJI_DATASOURCE_VERSION}/img/${set}/sheets-256/${sheetSize}.png`
+    uri: `https://unpkg.com/emoji-datasource-${set}@${EMOJI_DATASOURCE_VERSION}/img/${set}/sheets-256/${sheetSize}.png`,
   }),
   emojiImageFn: (image) => image,
   onPress: () => {},


### PR DESCRIPTION
the default spriteSheetFn prop is broken

it was returning undefined instead of { uri }